### PR TITLE
Replace deprecated macOS 13 runner image

### DIFF
--- a/.github/ci/matrix.json
+++ b/.github/ci/matrix.json
@@ -11,8 +11,8 @@
       "sde": "/home/runner/work/Stockfish/Stockfish/.output/sde-temp-files/sde-external-9.33.0-2024-01-07-lin/sde -future --"
     },
     {
-      "name": "MacOS 13 Apple Clang",
-      "os": "macos-13",
+      "name": "macOS 15 Apple Clang",
+      "os": "macos-15-intel",
       "simple_name": "macos",
       "compiler": "clang++",
       "comp": "clang",
@@ -20,7 +20,7 @@
       "archive_ext": "tar"
     },
     {
-      "name": "MacOS 14 Apple Clang M1",
+      "name": "macOS 14 Apple Clang M1",
       "os": "macos-14",
       "simple_name": "macos-m1",
       "compiler": "clang++",
@@ -126,31 +126,31 @@
     {
       "binaries": "x86-64-avxvnni",
       "config": {
-        "os": "macos-13"
+        "os": "macos-15-intel"
       }
     },
     {
       "binaries": "x86-64-avx512",
       "config": {
-        "os": "macos-13"
+        "os": "macos-15-intel"
       }
     },
     {
       "binaries": "x86-64-vnni256",
       "config": {
-        "os": "macos-13"
+        "os": "macos-15-intel"
       }
     },
     {
       "binaries": "x86-64-vnni512",
       "config": {
-        "os": "macos-13"
+        "os": "macos-15-intel"
       }
     },
     {
       "binaries": "x86-64-avx512icl",
       "config": {
-        "os": "macos-13"
+        "os": "macos-15-intel"
       }
     },
     {
@@ -234,7 +234,7 @@
     {
       "binaries": "apple-silicon",
       "config": {
-        "os": "macos-13"
+        "os": "macos-15-intel"
       }
     },
     {
@@ -258,7 +258,7 @@
     {
       "binaries": "armv8",
       "config": {
-        "os": "macos-13"
+        "os": "macos-15-intel"
       }
     },
     {
@@ -288,7 +288,7 @@
     {
       "binaries": "armv8-dotprod",
       "config": {
-        "os": "macos-13"
+        "os": "macos-15-intel"
       }
     },
     {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,21 +56,21 @@ jobs:
             base_image: "ppc64le/alpine:latest"
             platform: linux/ppc64le
             shell: bash
-          - name: MacOS 13 Apple Clang
-            os: macos-13
+          - name: macOS 15 Apple Clang
+            os: macos-15-intel
             compiler: clang++
             comp: clang
             run_64bit_tests: true
             shell: bash
-          - name: MacOS 14 Apple Clang M1
+          - name: macOS 14 Apple Clang M1
             os: macos-14
             compiler: clang++
             comp: clang
             run_64bit_tests: false
             run_m1_tests: true
             shell: bash
-          - name: MacOS 13 GCC 11
-            os: macos-13
+          - name: macOS 15 GCC 11
+            os: macos-15-intel
             compiler: g++-11
             comp: gcc
             run_64bit_tests: true


### PR DESCRIPTION
The macOS 13 runner image will be retired by December 4th, 2025.

No functional change